### PR TITLE
Fix missing textures cbmultipart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Change Magnesium for Rubidium (fix missing textures for CB Multipart)
+* Update CB Multipart and CodeChickenLib
+
 ## 1.3.2 - 2024-11-18
 
 * Add recipe to create create:white_sail from create:sail_frame

--- a/manifest.json
+++ b/manifest.json
@@ -102,7 +102,7 @@
     },
     {
       "projectID": 258426,
-      "fileID": 3529432,
+      "fileID": 3601708,
       "required": true
     },
     {
@@ -592,7 +592,7 @@
     },
     {
       "projectID": 242818,
-      "fileID": 3553742,
+      "fileID": 3681973,
       "required": true
     },
     {
@@ -696,8 +696,8 @@
       "required": true
     },
     {
-      "projectID": 532724,
-      "fileID": 3526076,
+      "projectID": 574856,
+      "fileID": 4743730,
       "required": true
     },
     {

--- a/modlist.html
+++ b/modlist.html
@@ -135,7 +135,7 @@
   <li><a href=https://www.curseforge.com/minecraft/mc-mods/configured>Configured(MrCrayfish)</a></li>
   <li><a href=https://www.curseforge.com/minecraft/mc-mods/occultism>Occultism(kli_kli)</a></li>
   <li><a href=https://www.curseforge.com/minecraft/mc-mods/chunknogobyebye>ChunkNoGoByeBye(LexManos)</a></li>
-  <li><a href=https://www.curseforge.com/minecraft/mc-mods/sodium-reforged>Magnesium(someoneelsewastaken)</a></li>
+  <li><a href=https://www.curseforge.com/minecraft/mc-mods/rubidium>Rubidium(Asek3)</a></li>
   <li><a href=https://www.curseforge.com/minecraft/mc-mods/phosphor-reforged>Sulfuric(someoneelsewastaken)</a></li>
   <li><a href=https://www.curseforge.com/minecraft/mc-mods/roadrunner>RoadRunner(MaxNeedsSnacks)</a></li>
 </ul>


### PR DESCRIPTION
Some of the CB Multipart mod elements are not rendering properly with Magnesium. 
This PR removes Magnesium, and adds Rubidium, which is the maintained, and supported version, and like Magnesium, it is a fork of the very same SODIUM mod. The PR also updates CB Multipart, and its dependency CodeChickenLib to the latest available version, compatible with current game version.  